### PR TITLE
Boolean options fixed

### DIFF
--- a/src/Controller/Component/FilterComponent.php
+++ b/src/Controller/Component/FilterComponent.php
@@ -213,10 +213,18 @@ class FilterComponent extends Component
         );
 
         if ($this->config('filterEmptyParams')) {
-            $searchParams = array_filter($searchParams);
+            $searchParams = array_filter(
+                    $searchParams,
+                    function ($v, $k) {
+                        if (($v === 0) || ($v === '0')) {
+                            return true;
+                        }
+                        return (bool)$v;
+                    },
+                    ARRAY_FILTER_USE_BOTH
+            );
         }
         $params['?'] = $searchParams;
-
         $params['action'] = $action;
         $this->controller()->redirect($params);
     }


### PR DESCRIPTION
When I created a filter with options Yes or Not in the controller

```
 'name' => 'my_field',
 'className' => 'Select', 'options' => [true => 'Yes', 'false' => 'No'],
```

the false value, return White URL, don´t search.

